### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/images/aikit-devel-ubuntu18.04/Dockerfile
+++ b/images/aikit-devel-ubuntu18.04/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 
 # install Intel(R) AI Analytics Toolkit
-RUN apt-get install -y -o=Dpkg::Use-Pty=0 \
+RUN apt-get --no-install-recommends install -y -o=Dpkg::Use-Pty=0 \
 intel-aikit-getting-started \
 intel-oneapi-common-vars \
 intel-oneapi-common-licensing \

--- a/images/basekit-devel-ubuntu18.04/Dockerfile
+++ b/images/basekit-devel-ubuntu18.04/Dockerfile
@@ -22,7 +22,7 @@ RUN echo "deb $apt_repo all main" > /etc/apt/sources.list.d/oneAPI.list
 RUN apt-get update -y
 
 # install Intel(R) oneAPI Base Toolkit
-RUN apt-get install -y -o=Dpkg::Use-Pty=0 \
+RUN apt-get --no-install-recommends install -y -o=Dpkg::Use-Pty=0 \
 intel-basekit-getting-started \
 intel-oneapi-onevpl-devel \
 intel-oneapi-common-vars \
@@ -45,7 +45,7 @@ intel-oneapi-advisor \
 
 # install Intel(R) Graphics Compute Runtime for OpenCL(TM)
 # https://github.com/intel/compute-runtime/releases/
-RUN apt-get install -y -o=Dpkg::Use-Pty=0 wget && \
+RUN apt-get --no-install-recommends install -y -o=Dpkg::Use-Pty=0 wget && \
 mkdir neo && \
 cd neo && \
 wget --no-verbose \

--- a/images/dlfdkit-devel-ubuntu18.04/Dockerfile
+++ b/images/dlfdkit-devel-ubuntu18.04/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 
 # install Intel(R) oneAPI DL Framework Developer Toolkit
-RUN apt-get install -y -o=Dpkg::Use-Pty=0 \
+RUN apt-get --no-install-recommends install -y -o=Dpkg::Use-Pty=0 \
 intel-dlfdkit-getting-started \
 intel-oneapi-common-vars \
 intel-oneapi-common-licensing \

--- a/images/hpckit-devel-ubuntu18.04/Dockerfile
+++ b/images/hpckit-devel-ubuntu18.04/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 
 # install Intel(R) oneAPI HPC Toolkit
-RUN apt-get install -y -o=Dpkg::Use-Pty=0 \
+RUN apt-get --no-install-recommends install -y -o=Dpkg::Use-Pty=0 \
 intel-hpckit-getting-started \
 intel-oneapi-common-vars \
 intel-oneapi-common-licensing \

--- a/images/iotkit-devel-ubuntu18.04/Dockerfile
+++ b/images/iotkit-devel-ubuntu18.04/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 
 # install Intel(R) oneAPI IoT Toolkit
-RUN apt-get install -y -o=Dpkg::Use-Pty=0 \
+RUN apt-get --no-install-recommends install -y -o=Dpkg::Use-Pty=0 \
 intel-iotkit-getting-started \
 intel-oneapi-common-vars \
 intel-oneapi-common-licensing \

--- a/images/os-tools-ubuntu18.04/Dockerfile
+++ b/images/os-tools-ubuntu18.04/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y
 
-RUN apt-get install -y -o=Dpkg::Use-Pty=0 \
+RUN apt-get --no-install-recommends install -y -o=Dpkg::Use-Pty=0 \
 # make
 build-essential \
 # library helper


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>