### PR TITLE
Transfer cmake from build to secondary container

### DIFF
--- a/images/docker/basekit/Dockerfile.ubuntu-18.04
+++ b/images/docker/basekit/Dockerfile.ubuntu-18.04
@@ -16,7 +16,7 @@ RUN cd /opt/build && \
 
 FROM ubuntu:18.04
 
-COPY --from=build /opt/dist /
+COPY --from=build /opt/dist/bin /bin
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1


### PR DESCRIPTION
I believe this will have the cmake executable transfer stages and be on the path of the following container and eliminate the call for the 2nd cmake install at line 34. 