### PR TITLE
Update CMake Version in Basekit Dockerfile

### DIFF
--- a/images/docker/basekit/Dockerfile.ubuntu-18.04
+++ b/images/docker/basekit/Dockerfile.ubuntu-18.04
@@ -10,9 +10,9 @@ RUN apt-get update && \
 
 # install cmake
 RUN cd /opt/build && \
-    curl -LO https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-linux-x86_64.sh && \
+    curl -LO https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.sh && \
     mkdir -p /opt/dist//usr/local && \
-    /bin/bash cmake-3.22.1-linux-x86_64.sh --prefix=/opt/dist//usr/local --skip-license
+    /bin/bash cmake-3.22.2-linux-x86_64.sh --prefix=/opt/dist//usr/local --skip-license
 
 
 # cleanup


### PR DESCRIPTION
## Description
The 2022 Intel C++ (Nextgen) compiler requires CMake 3.22.2 to work with Visual Studio. For this reason, the minimum required in the CMakeLists.txt might be 3.22.2 for some users, and this exact same CMakeLists.txt will fail when using the Basekit Docker container.

The solution proposed is to update the CMake version inside of the Docker container to 3.22.2.

## References
- https://gitlab.kitware.com/cmake/cmake/-/issues/23097
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6806

