### PR TITLE
Add missing hpckit to rockylinux-9

### DIFF
--- a/images/docker/hpckit/Dockerfile.rockylinux-9
+++ b/images/docker/hpckit/Dockerfile.rockylinux-9
@@ -26,7 +26,7 @@ gpgkey=https://repositories.intel.com/gpu/intel-graphics.key' \
 > /etc/yum.repos.d/intel-graphics.repo
 
 
-RUN yum update -y && yum install -y cmake procps make gcc gcc-c++ kernel-devel pkgconfig which bzip2 openssh-server openssh-clients wget net-tools git diffutils cmake intel-basekit intel-opencl intel-level-zero-gpu level-zero level-zero-devel 
+RUN yum update -y && yum install -y cmake procps make gcc gcc-c++ kernel-devel pkgconfig which bzip2 openssh-server openssh-clients wget net-tools git diffutils cmake intel-basekit intel-hpckit intel-opencl intel-level-zero-gpu level-zero level-zero-devel
 
 
 


### PR DESCRIPTION
The latest Rocky linux 9 HPC ToolKit image is missing the `intel-hpckit` package.
This PR adds the package to the image.