### PR TITLE
Fix amplxe-feedback call to 'file' command

### DIFF
--- a/images/docker/vtune/Dockerfile.ubuntu-20.04
+++ b/images/docker/vtune/Dockerfile.ubuntu-20.04
@@ -14,7 +14,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] h
 RUN mkdir -p /opt/workdir
 RUN apt-get update && apt-get upgrade -y && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git intel-oneapi-vtune  && \
+    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git file intel-oneapi-vtune  && \
   rm -rf /var/lib/apt/lists/*
 
 

--- a/images/docker/vtune/Dockerfile.ubuntu-22.04
+++ b/images/docker/vtune/Dockerfile.ubuntu-22.04
@@ -14,7 +14,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] h
 RUN mkdir -p /opt/workdir
 RUN apt-get update && apt-get upgrade -y && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git intel-oneapi-vtune  && \
+    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git file intel-oneapi-vtune  && \
   rm -rf /var/lib/apt/lists/*
 
 

--- a/images/docker/vtune/Dockerfile.ubuntu-24.04
+++ b/images/docker/vtune/Dockerfile.ubuntu-24.04
@@ -14,7 +14,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] h
 RUN mkdir -p /opt/workdir
 RUN apt-get update && apt-get upgrade -y && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git intel-oneapi-vtune  && \
+    ca-certificates build-essential pkg-config gnupg libarchive13 openssh-server openssh-client wget net-tools git file intel-oneapi-vtune  && \
   rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
When VTune encounters an error, the amplxe-feedback tool invokes the 'file' command to retrieve information about file type. However if the 'file' command is unavailable the following message is generated:

sh: 1: file: not found